### PR TITLE
fixed live cam issue

### DIFF
--- a/SimpleCV/Camera.py
+++ b/SimpleCV/Camera.py
@@ -380,7 +380,7 @@ class FrameSource:
                 #i.dl().text("Right click will kill the live image", (10,30), color=col)
                 i.dl().text( "%.1f" % elapsed_time, (i.width - 70 ,i.height  - 8), color=col)
 
-            i.save(d)
+            d.showImage(i)
 
 
 


### PR DESCRIPTION
Calling `cam.live()` multiple times was causing X Server errors.

Though I have no clue why this fixes it, but using `showImage` is the overall better way here as it avoid the overhead `save()` brings in
